### PR TITLE
Security Fix for `jsonwebtoken` Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "node-token-authentication",
   "main": "server.js",
   "dependencies": {
-    "jsonwebtoken": "~1.1.2",
-    "express": "~4.9.8",
-    "body-parser": "~1.9.2",
-    "mongoose": "~3.8.19",
-    "morgan": "~1.5.0"
+    "body-parser": "^1.15.0",
+    "express": "^4.13.4",
+    "jsonwebtoken": "^5.7.0",
+    "mongoose": "^4.4.5",
+    "morgan": "^1.7.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -79,7 +79,7 @@ apiRoutes.post('/authenticate', function(req, res) {
 				// if user is found and password is right
 				// create a token
 				var token = jwt.sign(user, app.get('superSecret'), {
-					expiresInMinutes: 1440 // expires in 24 hours
+					expiresIn: 86400 // expires in 24 hours
 				});
 
 				res.json({


### PR DESCRIPTION
Updated package.json and updated the token expiry time parameter as the old parameter was deprecated in the new version of jsonwebtoken. New expiresIn is in seconds only.

See here for details on vulnerability: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
