### PR TITLE
Fixed an issue where the JWT contained critical data.

### DIFF
--- a/server.js
+++ b/server.js
@@ -78,7 +78,10 @@ apiRoutes.post('/authenticate', function(req, res) {
 
 				// if user is found and password is right
 				// create a token
-				var token = jwt.sign(user, app.get('superSecret'), {
+				var payload = {
+					admin: user.admin	
+				}
+				var token = jwt.sign(payload, app.get('superSecret'), {
 					expiresIn: 86400 // expires in 24 hours
 				});
 


### PR DESCRIPTION
Until now, the JWT contained the entire mongoose user model,
which includes critical data like the users cleartext password.
We now only have selected properties inside the token to prevent that.

This fixes #8.